### PR TITLE
Fix IP Address Cropping

### DIFF
--- a/include/socket.klt
+++ b/include/socket.klt
@@ -16,7 +16,7 @@ TYPE
     connected  :  BOOLEAN
     status     :  INTEGER
     port       :  INTEGER
-    ip         :  STRING[13]
+    ip         :  STRING[15]
     number     :  INTEGER
     tag        :  STRING[3]
     env        :  STRING[13]


### PR DESCRIPTION
T_SOCKET.ip was cropping any IPv4 address longer than 13 characters in length. Bumping it to 15 should make it able to take max length addresses.